### PR TITLE
Update Jekyll to 4.0, fix jekyll_minimagic, pin gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
-gem "mini_magick"
-gem "jekyll-minimagick"
-gem "graphicsmagick"
-gem "jekyll", "~> 3.8"
+gem 'mini_magick', '~> 4.10', '>= 4.10.1'
+gem 'graphicsmagick', '~> 1.0', '>= 1.0.6'
+gem "jekyll", "~> 4.0"

--- a/_config.yml
+++ b/_config.yml
@@ -14,9 +14,6 @@ collections:
   guides:
       output: true
 
-plugins:
-    - jekyll-minimagick
-
 mini_magick:
     thumbnail:
         source: img/guides/original

--- a/_plugins/jekyll_minimagick.rb
+++ b/_plugins/jekyll_minimagick.rb
@@ -13,10 +13,7 @@ module Jekyll
       #
       # Returns <GeneratedImageFile>
       def initialize(site, base, dir, name, preset)
-        @site = site
-        @base = base
-        @dir  = dir
-        @name = name
+        super(site, base, dir, name)
         @dst_dir = preset.delete('destination')
         @src_dir = preset.delete('source')
         @commands = preset
@@ -39,14 +36,13 @@ module Jekyll
         dest_path = destination(dest)
 
         return false if File.exist? dest_path and !modified?
+
         self.class.mtimes[path] = mtime
 
         FileUtils.mkdir_p(File.dirname(dest_path))
         image = ::MiniMagick::Image.open(path)
-        image.combine_options do |c|
-          @commands.each_pair do |command, arg|
-            c.send command, arg
-          end
+        @commands.each_pair do |command, arg|
+          image.send command, arg
         end
         image.write dest_path
 
@@ -65,10 +61,8 @@ module Jekyll
         return unless site.config['mini_magick']
 
         site.config['mini_magick'].each_pair do |name, preset|
-          Dir.chdir preset['source'] do
-           Dir.glob(File.join("**", "*.{png,jpg,jpeg,gif,PNG,JPG,JPEG,GIF}")) do |source|
-              site.static_files << GeneratedImageFile.new(site, site.source, preset['destination'], source, preset.clone)
-             end
+          Dir.glob(File.join(site.source, preset['source'], "*.{png,jpg,jpeg,gif}")) do |source|
+            site.static_files << GeneratedImageFile.new(site, site.source, preset['destination'], File.basename(source), preset.clone)
           end
         end
       end


### PR DESCRIPTION
Fixes #44

Upravil jsem raději ten existujicí plugin, aby fungoval s 4.0, je to míň změn.